### PR TITLE
Make DigiNode Tools slightly more prominent

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -1692,6 +1692,17 @@
                 <div class="row testimonials downslide">
             
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Installeer & monitor DigiByte en/of DigiAssets node op Linux-masjiene.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besoek webtuiste</a>
+                            </div>
+                        </div>
                 
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1713,19 +1724,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Gaan na DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Installeer & monitor DigiByte en/of DigiAssets node op Linux-masjiene.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besoek webtuiste</a>
-                            </div>
-                        </div>
-                        
+                        </div>     
                 
                     </div>
                 </div>

--- a/ar/index.html
+++ b/ar/index.html
@@ -1671,6 +1671,17 @@
                 <h2 class="downtitle align-center"><i class="fas fa-server"></i> الأدوات والحلول.</h2>
                 
                 <div class="row testimonials downslide">
+
+                    <div class="testimonials__slide rtl">
+                        <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        <p>
+                            قم بتثبيت ومراقبة عقد DigiByte و / أو DigiAssets على أجهزة Linux.
+                        </p>
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiNode Tools</span>
+                            <a href="https://diginode.tools" target="_blank" class="testimonials__link">زيارة الموقع</a>
+                        </div>
+                    </div>
                     
                     <div class="col-full slick-slider testimonials__slider">
 
@@ -1695,18 +1706,6 @@
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">الانتقال إلى DigiByte API</a>
                             </div>
                         </div>
-
-                        <div class="testimonials__slide rtl">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                قم بتثبيت ومراقبة عقد DigiByte و / أو DigiAssets على أجهزة Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">زيارة الموقع</a>
-                            </div>
-                        </div>
-                        
 
                     </div>
                 </div>

--- a/bg/index.html
+++ b/bg/index.html
@@ -1695,6 +1695,17 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Инсталирайте и следете DigiByte и / или DigiAssets възли на машини с Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Посети уебсайтът</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Крайни Точки на Възела.<br>Blockchain RPC API.</p>
@@ -1713,17 +1724,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Към DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Инсталирайте и следете DigiByte и / или DigiAssets възли на машини с Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Посети уебсайтът</a>
                             </div>
                         </div>                        
 

--- a/cs/index.html
+++ b/cs/index.html
@@ -1693,6 +1693,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Nainstalujte a sledujte uzly DigiByte a / nebo DigiAssets na Linuxových strojích.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Nástroje DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Navštívit web</a>
+                            </div>
+                        </div>   
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1714,18 +1725,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Přejít na DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Nainstalujte a sledujte uzly DigiByte a / nebo DigiAssets na Linuxových strojích.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Nástroje DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Navštívit web</a>
-                            </div>
-                        </div>                        
+                        </div>                     
             
                     </div>
                 </div>

--- a/da/index.html
+++ b/da/index.html
@@ -1681,6 +1681,17 @@
                 <div class="row testimonials downslide">
                                 
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Installer og overvåg DigiByte og / eller DigiAssets noder på Linux-maskiner.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode-værktøjer</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besøg webstedet</a>
+                            </div>
+                        </div>  
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1702,18 +1713,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Gå til DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Installer og overvåg DigiByte og / eller DigiAssets noder på Linux-maskiner.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode-værktøjer</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besøg webstedet</a>
-                            </div>
-                        </div>                        
+                        </div>                      
             
                     </div>
                 </div>

--- a/de/index.html
+++ b/de/index.html
@@ -1688,6 +1688,17 @@
                 <div class="row testimonials downslide">
                                 
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Installieren und Überwachen von DigiByte- und/oder DigiAssets-Knoten auf Linux-Maschinen.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode-Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besuche die Website</a>
+                            </div>
+                        </div>  
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1709,18 +1720,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Zu DigiByte API gehen</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Installieren und Überwachen von DigiByte- und/oder DigiAssets-Knoten auf Linux-Maschinen.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode-Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besuche die Website</a>
-                            </div>
-                        </div>                        
+                        </div>                      
             
                     </div>
                 </div>

--- a/el/index.html
+++ b/el/index.html
@@ -1690,6 +1690,18 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Εγκαταστήστε και παρακολουθήστε κόμβους DigiByte και / ή DigiAssets σε μηχανές Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Εργαλεία DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Πήγαινε στη σελίδα</a>
+                            </div>
+                        </div>
+                        
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
                             <p>Κόμβοι DigiByte.<br>Αλυσίδα RPC API.</p>
@@ -1705,17 +1717,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Μετάβαση στο DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Εγκαταστήστε και παρακολουθήστε κόμβους DigiByte και / ή DigiAssets σε μηχανές Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Εργαλεία DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Πήγαινε στη σελίδα</a>
                             </div>
                         </div>
                         

--- a/en-au/index.html
+++ b/en-au/index.html
@@ -1758,6 +1758,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1776,19 +1789,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/en-ca/index.html
+++ b/en-ca/index.html
@@ -1736,6 +1736,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1754,19 +1767,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/en-gb/index.html
+++ b/en-gb/index.html
@@ -1736,6 +1736,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1754,19 +1767,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/en-in/index.html
+++ b/en-in/index.html
@@ -1758,6 +1758,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1776,19 +1789,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/en-ng/index.html
+++ b/en-ng/index.html
@@ -1747,6 +1747,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1765,19 +1778,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/en-nz/index.html
+++ b/en-nz/index.html
@@ -1747,6 +1747,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1766,20 +1779,6 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
-                            </div>
-                        </div>
 
                     </div>
                 </div>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -1725,6 +1725,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+    
+                            <p>
+                                DigiNode Tools makes it easy to set up, monitor and manage your own DigiByte full node and DigiAssets node on a Raspberry Pi or other Ubuntu/Debian system.
+                            </p>
+    
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1743,19 +1756,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Go to DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-    
-                            <p>
-                                Install & Monitor DigiByte and/or DigiAssets node on Linux Machines.
-                            </p>
-    
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visit website</a>
                             </div>
                         </div>
 

--- a/es/index.html
+++ b/es/index.html
@@ -1693,6 +1693,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Instale y monitoree nodos de DigiByte y/o DigiAssets en máquinas Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Herramientas de DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visitar web</a>
+                            </div>
+                        </div>  
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1714,18 +1725,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Ir a la API de DigiByte</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Instale y monitoree nodos de DigiByte y/o DigiAssets en máquinas Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Herramientas de DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visitar web</a>
-                            </div>
-                        </div>                        
+                        </div>                      
             
                     </div>
                 </div>

--- a/fa/index.html
+++ b/fa/index.html
@@ -1670,6 +1670,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide rtl">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            
+                            <p>
+                                نصب و نظارت بر گره های DigiByte و / یا DigiAssets در ماشین های لینوکس.
+                            </p>
+                            
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">ابزارهای DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">به وبسایت مراجعه کنید</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide rtl">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
                             
                             <p>پایان نقاط گره DigiByte.<br>API RPC زنجیره بلوک.</p>
@@ -1688,19 +1701,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">به DigiByte API بروید</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide rtl">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            
-                            <p>
-                                نصب و نظارت بر گره های DigiByte و / یا DigiAssets در ماشین های لینوکس.
-                            </p>
-                            
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">ابزارهای DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">به وبسایت مراجعه کنید</a>
                             </div>
                         </div>
                         

--- a/fi/index.html
+++ b/fi/index.html
@@ -1685,6 +1685,17 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Asenna ja valvo DigiByte- ja/tai DigiAssets-solmuja Linux-koneissa.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode-työkalut</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Vieraile sivustolla</a>
+                            </div>
+                        </div> 
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte-solmun päätepisteet.<br>Blockchain RPC -rajapinta.</p>
@@ -1704,18 +1715,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Siirry DigiByte Sovellusohjelmointiliittymä</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Asenna ja valvo DigiByte- ja/tai DigiAssets-solmuja Linux-koneissa.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode-työkalut</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Vieraile sivustolla</a>
-                            </div>
-                        </div>                        
+                        </div>                       
 
                     </div>
                 </div>

--- a/fil/index.html
+++ b/fil/index.html
@@ -1682,6 +1682,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                I-install at bantayan ang mga DigiByte at/o DigiAssets na node sa mga Linux machine.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Mga Tool ng DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Bisitahin ang website</a>
+                            </div>
+                        </div> 
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1703,18 +1714,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Pumunta sa DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                I-install at bantayan ang mga DigiByte at/o DigiAssets na node sa mga Linux machine.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Mga Tool ng DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Bisitahin ang website</a>
-                            </div>
-                        </div>                        
+                        </div>                       
             
                     </div>
                 </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1691,6 +1691,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Installer et surveiller les nœuds DigiByte et/ou DigiAssets sur des machines Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Outils DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visitez le site web</a>
+                            </div>
+                        </div>  
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1712,18 +1723,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Aller à DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Installer et surveiller les nœuds DigiByte et/ou DigiAssets sur des machines Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Outils DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visitez le site web</a>
-                            </div>
-                        </div>                        
+                        </div>                      
             
                     </div>
                 </div>

--- a/hi/index.html
+++ b/hi/index.html
@@ -1704,6 +1704,17 @@
                 <div class="row testimonials downslide">
                                 
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                लिनक्स मशीनों पर डिजिबाईट और / या डिजीएसेट नोड को इंस्टॉल और मॉनिटर करें।
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode टूल्स</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">बेवसाइट जाएँ</a>
+                            </div>
+                        </div>   
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1725,18 +1736,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">जाएं DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                लिनक्स मशीनों पर डिजिबाईट और / या डिजीएसेट नोड को इंस्टॉल और मॉनिटर करें।
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode टूल्स</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">बेवसाइट जाएँ</a>
-                            </div>
-                        </div>                        
+                        </div>                     
             
                     </div>
                 </div>

--- a/hr/index.html
+++ b/hr/index.html
@@ -1692,6 +1692,17 @@
                 <div class="row testimonials downslide">
                    
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Instalirajte i nadgledajte DigiByte i / ili DigiAssets čvor na Linux strojevima.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Alati</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Posjeti web stranicu</a>
+                            </div>
+                        </div>
                       
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1712,17 +1723,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Idi na DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Instalirajte i nadgledajte DigiByte i / ili DigiAssets čvor na Linux strojevima.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Alati</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Posjeti web stranicu</a>
                             </div>
                         </div>
                         

--- a/hu/index.html
+++ b/hu/index.html
@@ -1686,6 +1686,17 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Telepítse és figyelje a DigiByte és / vagy DigiAssets csomópontot Linux gépeken.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Eszközök</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Látogass el a weboldalra</a>
+                            </div>
+                        </div> 
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Végpontok.<br>Blockchain RPC API.</p>
@@ -1705,18 +1716,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Menj a DigiByte API-hoz</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Telepítse és figyelje a DigiByte és / vagy DigiAssets csomópontot Linux gépeken.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Eszközök</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Látogass el a weboldalra</a>
-                            </div>
-                        </div>                        
+                        </div>                       
 
                     </div>
                 </div>

--- a/id/index.html
+++ b/id/index.html
@@ -1696,6 +1696,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Pasang dan monitor DigiByte dan/atau DigiAssets node pada mesin Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Alat DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Kunjungi situs web</a>
+                            </div>
+                        </div> 
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1717,18 +1728,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Buka API DigiByte</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Pasang dan monitor DigiByte dan/atau DigiAssets node pada mesin Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Alat DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Kunjungi situs web</a>
-                            </div>
-                        </div>                        
+                        </div>                       
             
                     </div>
                 </div>

--- a/it/index.html
+++ b/it/index.html
@@ -1692,6 +1692,17 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            <p>
+                                Installa e monitora il nodo DigiByte e/o DigiAssets su macchine Linux.
+                            </p>
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">Strumenti DigiNode</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visita il sito</a>
+                            </div>
+                        </div>
                         
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1712,17 +1723,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Vai all'API DigiByte</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            <p>
-                                Installa e monitora il nodo DigiByte e/o DigiAssets su macchine Linux.
-                            </p>
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">Strumenti DigiNode</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visita il sito</a>
                             </div>
                         </div>                        
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -1672,6 +1672,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Linuxマシン上でDigiByteと/またはDigiAssetsノードをインストールおよび監視します。
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNodeツール</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">ウェブサイトを訪れる</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1692,19 +1705,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">DigiByte APIに移動</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Linuxマシン上でDigiByteと/またはDigiAssetsノードをインストールおよび監視します。
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNodeツール</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">ウェブサイトを訪れる</a>
                             </div>
                         </div>
                         

--- a/ko/index.html
+++ b/ko/index.html
@@ -1706,6 +1706,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                리눅스 기계에서 DigiByte와/또는 DigiAssets 노드를 설치하고 모니터링합니다.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">웹사이트 방문</a>
+                            </div>
+                        </div>  
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1727,20 +1740,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">DigiByte API로 이동</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                리눅스 기계에서 DigiByte와/또는 DigiAssets 노드를 설치하고 모니터링합니다.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">웹사이트 방문</a>
-                            </div>
-                        </div>                        
+                        </div>                      
             
                     </div>
                 </div>

--- a/ms/index.html
+++ b/ms/index.html
@@ -1696,6 +1696,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Pasang & Pantau nod DigiByte dan/atau DigiAssets pada Mesin Linux.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Kunjungi laman sesawang</a>
+                            </div>
+                        </div>  
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
                             
                             <p>Titik Akhir Nod DigiByte.<br>Blockchain RPC API.</p>
@@ -1715,20 +1728,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Pergi ke DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Pasang & Pantau nod DigiByte dan/atau DigiAssets pada Mesin Linux.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Kunjungi laman sesawang</a>
-                            </div>
-                        </div>                        
+                        </div>                      
 
                     </div>
                 </div>

--- a/nb/index.html
+++ b/nb/index.html
@@ -1685,6 +1685,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Installer og overvåk DigiByte og/eller DigiAssets-node på Linux-maskiner.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode-verktøy</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besøk nettsiden</a>
+                            </div>
+                        </div>  
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte-node endpoints.<br>Blockchain RPC API.</p>
@@ -1704,20 +1717,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Gå til DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Installer og overvåk DigiByte og/eller DigiAssets-node på Linux-maskiner.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode-verktøy</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besøk nettsiden</a>
-                            </div>
-                        </div>                        
+                        </div>                      
 
                     </div>
                 </div>

--- a/nl/index.html
+++ b/nl/index.html
@@ -1702,6 +1702,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Installeer en monitor DigiByte en/of DigiAssets node op Linux machines.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Bezoek de website</a>
+                            </div>
+                        </div>   
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1723,20 +1736,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Ga naar DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Installeer en monitor DigiByte en/of DigiAssets node op Linux machines.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Bezoek de website</a>
-                            </div>
-                        </div>                        
+                        </div>                     
             
                     </div>
                 </div>

--- a/pl/index.html
+++ b/pl/index.html
@@ -1695,6 +1695,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Zainstaluj i monitoruj węzły DigiByte i/lub DigiAssets na maszynach z systemem Linux.https://github.com/saltedlolly/diginode-tools
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Odwiedź stronę</a>
+                            </div>
+                        </div>  
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>DigiByte Node Endpoints.<br>Blockchain RPC API.</p>
@@ -1714,20 +1727,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Przejdź do interfejsu API DigiByte</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Zainstaluj i monitoruj węzły DigiByte i/lub DigiAssets na maszynach z systemem Linux.https://github.com/saltedlolly/diginode-tools
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Odwiedź stronę</a>
-                            </div>
-                        </div>                        
+                        </div>                      
 
                     </div>
                 </div>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -1684,6 +1684,19 @@
 
                    <div class="col-full slick-slider testimonials__slider">
 
+                    <div class="testimonials__slide">
+                      <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                  
+                      <p>
+                          Instale e monitore o nó DigiByte e/ou DigiAssets em máquinas Linux.
+                      </p>
+                  
+                      <div class="testimonials__author">
+                          <span class="testimonials__name">DigiNode Tools</span>
+                          <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visite o site</a>
+                      </div>
+                  </div>  
+
                       <div class="testimonials__slide">
                          <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
                          
@@ -1704,20 +1717,7 @@
                             <span class="testimonials__name">NowNodes</span>
                             <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Acessar DigiByte API</a>
                          </div>
-                      </div>
-
-                      <div class="testimonials__slide">
-                        <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                    
-                        <p>
-                            Instale e monitore o nó DigiByte e/ou DigiAssets em máquinas Linux.
-                        </p>
-                    
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DigiNode Tools</span>
-                            <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visite o site</a>
-                        </div>
-                    </div>                    
+                      </div>                  
 
                    </div>
                 </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -1720,6 +1720,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Instale e monitore os nós DigiByte e/ou DigiAssets em máquinas Linux.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visite o site</a>
+                            </div>
+                        </div>  
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
 
                             <p>Endpoints do nó DigiByte.<br>API de blockchain RPC.</p>
@@ -1739,20 +1752,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Ir para a API DigiByte</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Instale e monitore os nós DigiByte e/ou DigiAssets em máquinas Linux.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Visite o site</a>
-                            </div>
-                        </div>                        
+                        </div>                      
 
                     </div>
                 </div>

--- a/ro/index.html
+++ b/ro/index.html
@@ -1691,6 +1691,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                            
+                            <p>
+                                Instalați și monitorizați nodul DigiByte și/sau DigiAssets pe mașini Linux.
+                            </p>
+                            
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Viziteaza website-ul</a>
+                            </div>
+                        </div>
                         
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1711,19 +1724,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Accesați DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                            
-                            <p>
-                                Instalați și monitorizați nodul DigiByte și/sau DigiAssets pe mașini Linux.
-                            </p>
-                            
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Viziteaza website-ul</a>
                             </div>
                         </div>
                         

--- a/ru/index.html
+++ b/ru/index.html
@@ -1670,6 +1670,19 @@
                 <div class="row testimonials downslide">
                                 
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Установка и мониторинг нод DigiByte и / или DigiAssets на Linux-машинах.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Посетите сайт</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1690,19 +1703,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Перейти к DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Установка и мониторинг нод DigiByte и / или DigiAssets на Linux-машинах.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Посетите сайт</a>
                             </div>
                         </div>                        
             

--- a/sl/index.html
+++ b/sl/index.html
@@ -1692,6 +1692,19 @@
                     <div class="col-full slick-slider testimonials__slider">
 
                         <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Namestite in spremljajte vozlišča DigiByte in/ali DigiAssets na Linux strojih.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Orodja</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Obišči spletno stran</a>
+                            </div>
+                        </div>
+
+                        <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
                             
                             <p>DigiByte vozliščni konci.<br>Blockchain RPC API.</p>
@@ -1710,19 +1723,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Pojdi na DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Namestite in spremljajte vozlišča DigiByte in/ali DigiAssets na Linux strojih.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Orodja</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Obišči spletno stran</a>
                             </div>
                         </div>                        
 

--- a/sq/index.html
+++ b/sq/index.html
@@ -1683,6 +1683,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Instaloni dhe monitoroni nodat e DigiByte dhe/ose DigiAssets në makinat Linux.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Vizitoni faqen e internetit</a>
+                            </div>
+                        </div> 
              
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1704,20 +1717,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Shko te DigiByte API</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Instaloni dhe monitoroni nodat e DigiByte dhe/ose DigiAssets në makinat Linux.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Vizitoni faqen e internetit</a>
-                            </div>
-                        </div>                        
+                        </div>                       
              
                     </div>
                 </div>

--- a/sv/index.html
+++ b/sv/index.html
@@ -1692,6 +1692,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Installera och övervaka DigiByte- och/eller DigiAssets-nod på Linux-maskiner.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besök webbsida</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1712,19 +1725,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Gå till DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Installera och övervaka DigiByte- och/eller DigiAssets-nod på Linux-maskiner.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Besök webbsida</a>
                             </div>
                         </div>                        
             

--- a/sw/index.html
+++ b/sw/index.html
@@ -1672,6 +1672,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Sakinisha na fuatilia node za DigiByte na / au DigiAssets kwenye Mashine za Linux.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Tembelea tovuti</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1692,19 +1705,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Nenda kwenye DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Sakinisha na fuatilia node za DigiByte na / au DigiAssets kwenye Mashine za Linux.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Tembelea tovuti</a>
                             </div>
                         </div>                        
             

--- a/th/index.html
+++ b/th/index.html
@@ -1682,6 +1682,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                ติดตั้งและตรวจสอบโหนด DigiByte และ / หรือ DigiAssets บนเครื่อง Linux
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">เยี่ยมชมเว็บไซต์</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1702,19 +1715,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">ไปที่ DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                ติดตั้งและตรวจสอบโหนด DigiByte และ / หรือ DigiAssets บนเครื่อง Linux
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">เยี่ยมชมเว็บไซต์</a>
                             </div>
                         </div>                        
             

--- a/tr/index.html
+++ b/tr/index.html
@@ -1693,6 +1693,19 @@
                 <div class="row testimonials downslide">
                     
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Linux makinelerinde DigiByte ve/veya DigiAssets düğümünü yükleyin ve izleyin.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Araçları</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Web sitesine git</a>
+                            </div>
+                        </div> 
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1714,20 +1727,7 @@
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">DigiByte API'ya Git</a>
                             </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Linux makinelerinde DigiByte ve/veya DigiAssets düğümünü yükleyin ve izleyin.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Araçları</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Web sitesine git</a>
-                            </div>
-                        </div>                        
+                        </div>                       
             
                     </div>
                 </div>

--- a/vi/index.html
+++ b/vi/index.html
@@ -1694,6 +1694,19 @@
                 <div class="row testimonials downslide">
             
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                Cài đặt & giám sát DigiByte và/hoặc nút DigiAssets trên các máy Linux.
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode Tools</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Thăm website</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1714,19 +1727,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">Đi đến DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                Cài đặt & giám sát DigiByte và/hoặc nút DigiAssets trên các máy Linux.
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode Tools</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">Thăm website</a>
                             </div>
                         </div>                        
             

--- a/zh/index.html
+++ b/zh/index.html
@@ -1681,6 +1681,19 @@
                 <div class="row testimonials downslide">
                                 
                     <div class="col-full slick-slider testimonials__slider">
+
+                        <div class="testimonials__slide">
+                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
+                        
+                            <p>
+                                在 Linux 机器上安装和监控 DigiByte 和/或 DigiAssets 节点。
+                            </p>
+                        
+                            <div class="testimonials__author">
+                                <span class="testimonials__name">DigiNode 工具</span>
+                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">访问网站</a>
+                            </div>
+                        </div>
             
                         <div class="testimonials__slide">
                             <img src="../images/avatars/getblock-inverted-primary-icon.svg" loading="lazy" width="72" height="72" alt="GetBlock" target="_blank" class="testimonials__avatar">
@@ -1701,19 +1714,6 @@
                             <div class="testimonials__author">
                                 <span class="testimonials__name">NowNodes</span>
                                 <a href="https://nownodes.io/nodes/digibyte-dgb" target="_blank" class="testimonials__link">转到 DigiByte API</a>
-                            </div>
-                        </div>
-
-                        <div class="testimonials__slide">
-                            <img src="../images/avatars/diginode_round.svg" loading="lazy" width="72" height="72" alt="Digi-ID Desktop" class="testimonials__avatar">
-                        
-                            <p>
-                                在 Linux 机器上安装和监控 DigiByte 和/或 DigiAssets 节点。
-                            </p>
-                        
-                            <div class="testimonials__author">
-                                <span class="testimonials__name">DigiNode 工具</span>
-                                <a href="https://diginode.tools" target="_blank" class="testimonials__link">访问网站</a>
                             </div>
                         </div>                        
             


### PR DESCRIPTION
Sorry I made a couple more tweaks. 

Given how much time I have spent working on DigiNode Tools, I hope noone objects to me making it slightly more prominent on the digibyte.org website:
- Bumped DigiNode Tools to the front of the "Tools & Solutions" section so it is visible on the page at load time. (no need to click right)
- Updated English description (I have not translated this but the DigiNode site is currently only in English. For other languages the original description is fine.)

If it encourages more people to run a node then great.