### PR TITLE
feature: Remove DGBCommerce as it has been shut down.

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -1179,17 +1179,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                    
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce is 'n e-handelsplatform deur en vir DigiByte-gebruikers.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/ar/index.html
+++ b/ar/index.html
@@ -1155,17 +1155,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce هي منصة تجارة إلكترونية من ولأجل مستخدمي DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/bg/index.html
+++ b/bg/index.html
@@ -1177,17 +1177,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce е платформа за електронна търговия от и за потребителите на DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/cs/index.html
+++ b/cs/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                    
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce je e-commerce platforma vytvořená pro uživatele DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/da/index.html
+++ b/da/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce er en e-handelsplatform af og for DigiByte-brugere.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/de/index.html
+++ b/de/index.html
@@ -1173,17 +1173,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce ist eine E-Commerce-Plattform von und für DigiByte-Benutzer</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/el/index.html
+++ b/el/index.html
@@ -1176,17 +1176,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>Το DGB Commerce είναι μια πλατφόρμα ηλεκτρονικού εμπορίου από και για τους χρήστες του DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -1185,17 +1185,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                                            
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce is an e-commerce platform by and for DigiByte users.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/es/index.html
+++ b/es/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce es una plataforma de comercio electrónico creada por y para usuarios de DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/fa/index.html
+++ b/fa/index.html
@@ -1155,17 +1155,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide rtl">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce یک پلتفرم تجارت الکترونیکی توسط و برای کاربران DigiByte است.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/fi/index.html
+++ b/fi/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce on e-kaupankäyntialusta DigiByte-käyttäjille.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/fil/index.html
+++ b/fil/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>Ang DGB Commerce ay isang plataporma ng e-commerce na ginawa para sa mga gumagamit ng DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/fr/index.html
+++ b/fr/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce est une plateforme de commerce électronique par et pour les utilisateurs de DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/hi/index.html
+++ b/hi/index.html
@@ -1188,17 +1188,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce एक ई-कॉमर्स प्लेटफ़ॉर्म है जिसे DigiByte उपयोगकर्ताओं द्वारा और के लिए बनाया गया है।</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/hr/index.html
+++ b/hr/index.html
@@ -1179,17 +1179,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce je platforma za e-trgovinu od strane i za korisnike DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/hu/index.html
+++ b/hu/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>A DGB Commerce egy e-kereskedelmi platform, amelyet a DigiByte felhasználói hoztak létre és használnak.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/id/index.html
+++ b/id/index.html
@@ -1181,17 +1181,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce adalah platform e-commerce oleh dan untuk pengguna DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/index.html
+++ b/index.html
@@ -1197,17 +1197,6 @@
                         </div>
                     </div>
 
-                    <div class="testimonials__slide">
-                        <img src="images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce is an e-commerce platform by and for DigiByte users.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
-
                 </div>
 	    
 	        </div>

--- a/it/index.html
+++ b/it/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce è una piattaforma di e-commerce creata da e per gli utenti di DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/ja/index.html
+++ b/ja/index.html
@@ -1156,17 +1156,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce は DigiByte ユーザーのための電子商取引プラットフォームです。</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/ko/index.html
+++ b/ko/index.html
@@ -1190,17 +1190,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                    
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB 커머스는 DigiByte 사용자들을 위해 만들어진 전자 상거래 플랫폼입니다.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 

--- a/ms/index.html
+++ b/ms/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce adalah platform e-dagang oleh dan untuk pengguna DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/nb/index.html
+++ b/nb/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce er en e-handelsplattform av og for DigiByte-brukere.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/nl/index.html
+++ b/nl/index.html
@@ -1188,17 +1188,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce is een e-commerce platform door en voor DigiByte gebruikers.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/pl/index.html
+++ b/pl/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce to platforma e-commerce stworzona przez i dla użytkowników DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                                            
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce é uma plataforma de e-commerce feita por e para os usuários de DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/pt/index.html
+++ b/pt/index.html
@@ -1204,17 +1204,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce é uma plataforma de e-commerce feita por e para os usuários de DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/ro/index.html
+++ b/ro/index.html
@@ -1177,17 +1177,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce este o platformă de comerț electronic creată de și pentru utilizatorii DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/ru/index.html
+++ b/ru/index.html
@@ -1156,17 +1156,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce - это платформа электронной коммерции для пользователей DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/sl/index.html
+++ b/sl/index.html
@@ -1176,17 +1176,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce je platforma za e-trgovino od in za uporabnike DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/sq/index.html
+++ b/sq/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce është një platformë tregtare elektronike nga dhe për përdoruesit e DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/sv/index.html
+++ b/sv/index.html
@@ -1176,17 +1176,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce är en e-handelsplattform av och för DigiByte-användare.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/sw/index.html
+++ b/sw/index.html
@@ -1156,17 +1156,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce ni jukwaa la biashara mtandaoni kwa na kwa watumiaji wa DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/th/index.html
+++ b/th/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce เป็นแพลตฟอร์มอีคอมเมิร์ซที่ถูกสร้างขึ้นโดยและสำหรับผู้ใช้ DigiByte</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/tr/index.html
+++ b/tr/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce, DigiByte kullanıcıları tarafından ve için oluşturulmuş bir e-ticaret platformudur.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/vi/index.html
+++ b/vi/index.html
@@ -1178,17 +1178,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce là một nền tảng thương mại điện tử được tạo ra bởi và dành cho người dùng DigiByte.</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    

--- a/zh/index.html
+++ b/zh/index.html
@@ -1167,17 +1167,6 @@
                             <a href="https://changeangel.io" target="_blank" class="testimonials__link">changeangel.io</a> - <a href="https://changeangel.io/buy-dgb" target="_blank" class="testimonials__link">buy dgb</a>
                         </div>
                     </div>
-                                        
-                    <div class="testimonials__slide">
-                        <img src="/images/avatars/dgbcommerce.png" loading="lazy" width="72" height="72" alt="dgbcommerce" class="testimonials__avatar">
-                        
-                        <p>DGB Commerce 是由 DigiByte 用户创建和使用的电子商务平台。</p>
-
-                        <div class="testimonials__author">
-                            <span class="testimonials__name">DGB Commerce</span>
-                            <a href="https://www.dgbcommerce.com/" target="_blank" class="testimonials__link">dgbcommerce.com</a>
-                        </div>
-                    </div>
 
                 </div>
 	    


### PR DESCRIPTION
This PR removes the DGBCommerce link as the service has been shut down by the creator.